### PR TITLE
Run `losf` from within Riak using `os:cmd/1`.

### DIFF
--- a/src/check_file_handle_count.erl
+++ b/src/check_file_handle_count.erl
@@ -1,0 +1,49 @@
+-module(check_file_handle_count).
+
+-export([run/2]).
+
+%% pass check level options after "--"
+%% check_node file_handle_count -- --warning_threshold=50
+run(Options, NonOptArgs) ->
+    OptSpecList = option_spec_list(),
+    case getopt:parse(OptSpecList, NonOptArgs) of
+        {ok, {CmdOptions, _}} ->
+            run_cmd(Options, CmdOptions);
+        {error, {Reason, Data}} ->
+            {unknown, "~s ~p", [Reason, Data]}
+    end.
+
+run_cmd(Options, CmdOptions) ->
+    Node = proplists:get_value(node, Options),
+    Pid = rpc:call(Node, os, getpid, []),
+    %% os:cmd/1 does not return exit code so we fake it the best way we can
+    Cmd = "O=$(lsof -p " ++ Pid ++ "  2>&1);echo $?;echo \"$O\"",    
+    Resp = rpc:call(Node, os, cmd, [Cmd]),
+    Lines = string:tokens(Resp, "\n"),
+    ExitCode = list_to_integer(lists:nth(1, Lines)),
+    Output = lists:nthtail(1, Lines),
+    handle_output(ExitCode, Output, Options, CmdOptions).
+
+handle_output(0, Output, _Options, CmdOptions) ->
+    %% subtract 1 to account for lsof header
+    Count = length(Output) - 1,
+    Critical = proplists:get_value(critical, CmdOptions),
+    Warning = proplists:get_value(warning, CmdOptions),
+    Msg = "~B file descriptors in use",
+    if
+        Count >= Critical -> {critical, Msg, [Count]};
+        Count >= Warning -> {warning, Msg, [Count]};
+        true -> {ok, Msg, [Count]}
+    end;
+
+handle_output(Err, Output, _Options, _CmdOptions) ->
+    FirstLine = lists:nth(1, Output),
+    {unknown, "Error code: ~B, message: ~s", [Err, FirstLine]}.
+
+option_spec_list() ->
+    [
+    %% {Name, ShortOpt, LongOpt, ArgSpec, HelpMsg}
+    {warning, undefined, "warning_threshold", {integer, 5000}, "Warning threshold"},
+    {critical, undefined, "critical_threshold", {integer, 10000}, "Critical threshold"}
+    ].
+

--- a/src/check_node.erl
+++ b/src/check_node.erl
@@ -66,9 +66,10 @@ run_check(Check, Options, NonOptArgs) ->
 
 checks() ->
     [
-        {riak_repl, check_riak_repl},
         {node_up, check_node_up},
-        {riak_kv_up, check_riak_kv_up}
+        {riak_kv_up, check_riak_kv_up},
+        {file_handle_count, check_file_handle_count},
+        {riak_repl, check_riak_repl}
     ].
 
 usage() ->


### PR DESCRIPTION
This avoids having to worry about permissions when running `lsof`. A shell script run as the `nagios` user is not be able to see all files opened by Riak. Running the command from within Riak ensures we have the necessary permissions to see all open files.
