### PR TITLE
Make check_file_handle_count runnable by non-privileged users

### DIFF
--- a/bin/riak-check-files.sh
+++ b/bin/riak-check-files.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
 ##
-# Usage: check_files.sh 'Node name' [Limit] [Critical Limit]
+# Usage: check_files.sh [Limit] [Critical Limit]
 #
-# Locates the PID for the beam process running the specified node
-# counts the number of files handles that PID is using via lsof
+# Compares the number of open file handles against user supplied limits
 # returns nagios compatible responses
 #
 # Unspecified argument defaults:
-#    Node name      - riak@<host fqdn>
-#    Limit          - 5000
+#    Warning Limit  - 5000
 #    Critical Limit - 10000
 #
 ##
@@ -25,13 +23,10 @@
 #                                      #
 ########################################
 
-TargetNode=$1
-WarnLim=${2:-5000}
-CritLim=${3:-10000}
-[ -z "$TargetNode" ] && TargetNode="riak@`hostname -f`"
+WarnLim=${1:-5000}
+CritLim=${2:-10000}
 
-pid=$(ps axww 2>/dev/null | grep beam.smp 2>/dev/null | sed -n -e "/$TargetNode/s/^[ ]*\([0-9]*\).*$/\1 /p" 2>&1)
-[[ "$pid" =~ ^[\ ]*[0-9]+[\ ]*$ ]] &&  fdcount=$(lsof -p $pid 2>/dev/null | wc -l 2>&1)
+fdcount=$(awk '{print $1}' /proc/sys/fs/file-nr 2>/dev/null)
 if [ $? = 0 ] && [[ "$fdcount" =~ ^[\ ]*[0-9]+[\ ]*$ ]]; then
     if [ $fdcount -lt $WarnLim ]; then
         echo "OKAY: $fdcount / $WarnLim file descriptors in use."
@@ -45,7 +40,7 @@ if [ $? = 0 ] && [[ "$fdcount" =~ ^[\ ]*[0-9]+[\ ]*$ ]]; then
         echo "WARNING: $fdcount / $WarnLim file descriptors in use."
         exit 1
     fi
-    echo "CRITICAL: Could not evaluate count $fdcount against limits $WarnLim and $Critlim on node $TargetNode"
+    echo "CRITICAL: Could not evaluate count $fdcount against limits $WarnLim and $Critlim"
     exit 2
 else
     echo "CRITICAL: Unable to get file descriptor count."

--- a/src/check_file_handle_count.erl
+++ b/src/check_file_handle_count.erl
@@ -15,9 +15,8 @@ run(Options, NonOptArgs) ->
 
 run_cmd(Options, CmdOptions) ->
     Node = proplists:get_value(node, Options),
-    Pid = rpc:call(Node, os, getpid, []),
     %% os:cmd/1 does not return exit code so we fake it the best way we can
-    Cmd = "O=$(lsof -n -p " ++ Pid ++ "  2>/dev/null|wc -l);echo $?;echo ${O}",
+    Cmd = "O=$(awk '{print $1}' /proc/sys/fs/file-nr 2>/dev/null);echo $?;echo ${O}",
     Resp = rpc:call(Node, os, cmd, [Cmd]),
     [ExitCode0|Output] = string:tokens(Resp, "\n"),
     ExitCode = list_to_integer(ExitCode0),


### PR DESCRIPTION
Nagios checks are most often run by the non-privileged "nagios" user.  The current implementation of check_file_handle_count relies on lsof for the specific Riak process, an operation that requires root privileges to perform.

This commit changes the behavior of check_file_handle_count to evaluate the total system file handles (which a  non-privileged user can query) against the warn/crit limits rather than using lsof specifically for the Riak process.  While this is not as accurate, it will be more usable for a wider audience.  

I believe the loss of accuracy is acceptable given most architectures have Riak deployed as the only major consumer of file handles on a server.  Worst case, we alert sooner than we would have otherwise.
